### PR TITLE
Add support for urls with query strings

### DIFF
--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -221,7 +221,8 @@ class Crawler
 
             $url->setScheme($this->baseUrl->scheme)
                 ->setHost($this->baseUrl->host)
-                ->setPort($this->baseUrl->port);
+                ->setPort($this->baseUrl->port)
+                ->setQuery($this->baseUrl->query);
         }
 
         if ($url->isProtocolIndependent()) {

--- a/src/Url.php
+++ b/src/Url.php
@@ -169,11 +169,10 @@ class Url
         $path = starts_with($this->path, '/') ? substr($this->path, 1) : $this->path;
 
         $port = ($this->port === 80 ? '' : ":{$this->port}");
-        
-		$query = '';
 
-        if(isset($this->query) && $this->query != '')
-        {
+        $query = '';
+
+        if (isset($this->query) && $this->query != '') {
             $query = '?' . $this->query;
         }
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -24,6 +24,11 @@ class Url
     /**
      * @var null|string
      */
+    public $query;
+
+    /**
+     * @var null|string
+     */
     public $path;
 
     /**
@@ -45,7 +50,7 @@ class Url
     {
         $urlProperties = parse_url($url);
 
-        foreach (['scheme', 'host', 'path', 'port'] as $property) {
+        foreach (['scheme', 'host', 'path', 'port', 'query'] as $property) {
             if (isset($urlProperties[$property])) {
                 $this->$property = $urlProperties[$property];
             }
@@ -129,6 +134,20 @@ class Url
     }
 
     /**
+     * Set the query.
+     *
+     * @param string $query
+     *
+     * @return $this
+     */
+    public function setQuery($query)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    /**
      * Remove the fragment.
      *
      * @return $this
@@ -150,7 +169,14 @@ class Url
         $path = starts_with($this->path, '/') ? substr($this->path, 1) : $this->path;
 
         $port = ($this->port === 80 ? '' : ":{$this->port}");
+        
+		$query = '';
 
-        return "{$this->scheme}://{$this->host}{$port}/{$path}";
+        if(isset($this->query) && $this->query != '')
+        {
+            $query = '?' . $this->query;
+        }
+
+        return "{$this->scheme}://{$this->host}{$port}/{$path}{$query}";
     }
 }

--- a/tests/Unit/UrlTest.php
+++ b/tests/Unit/UrlTest.php
@@ -16,7 +16,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->testUrl = new Url('https://spatie.be/opensource');
+        $this->testUrl = new Url('https://spatie.be/opensource?query=test');
     }
 
     /**
@@ -28,6 +28,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('spatie.be', $this->testUrl->host);
         $this->assertEquals(80, $this->testUrl->port);
         $this->assertEquals('/opensource', $this->testUrl->path);
+        $this->assertEquals('query=test', $this->testUrl->query);
     }
 
     /**
@@ -35,7 +36,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
      */
     public function it_can_be_converted_to_a_string()
     {
-        $this->assertEquals('https://spatie.be/opensource', (string) $this->testUrl);
+        $this->assertEquals('https://spatie.be/opensource?query=test', (string) $this->testUrl);
     }
 
     /**
@@ -73,7 +74,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     {
         $this->testUrl->setHost('google.com');
 
-        $this->assertEquals('https://google.com/opensource', (string) $this->testUrl);
+        $this->assertEquals('https://google.com/opensource?query=test', (string) $this->testUrl);
     }
 
     /**
@@ -83,7 +84,17 @@ class UrlTest extends PHPUnit_Framework_TestCase
     {
         $this->testUrl->setScheme('http');
 
-        $this->assertEquals('http://spatie.be/opensource', (string) $this->testUrl);
+        $this->assertEquals('http://spatie.be/opensource?query=test', (string) $this->testUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_change_the_query()
+    {
+        $this->testUrl->setQuery('query=new');
+
+        $this->assertEquals('https://spatie.be/opensource?query=new', (string) $this->testUrl);
     }
 
     /**
@@ -123,7 +134,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $this->testUrl->setPort(3000);
 
         $this->assertEquals(3000, $this->testUrl->port);
-        $this->assertEquals('https://spatie.be:3000/opensource', (string) $this->testUrl);
+        $this->assertEquals('https://spatie.be:3000/opensource?query=test', (string) $this->testUrl);
     }
 
     /**
@@ -133,6 +144,6 @@ class UrlTest extends PHPUnit_Framework_TestCase
     {
         $this->testUrl->setPort(80);
 
-        $this->assertEquals('https://spatie.be/opensource', (string) $this->testUrl);
+        $this->assertEquals('https://spatie.be/opensource?query=test', (string) $this->testUrl);
     }
 }


### PR DESCRIPTION
Some URLs are only accessible when a query string is present in the URL. This will add support for these URLs so that a request does not respond with a 404 if missing.

Some websites that use content management systems for managing files and webpages require such query strings.
