### PR TITLE
Trim Url before creating.

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -32,12 +32,17 @@ class Url
     public $path;
 
     /**
+     * Create a new static Url.
+     * Remove any mistakenly added spaces from the beginning and end of the Url string.
+     *
      * @param $url
      *
      * @return static
      */
     public static function create($url)
     {
+        $url = trim($url);
+
         return new static($url);
     }
 


### PR DESCRIPTION
We have come across an issue when crawling webpages that include hrefs that mistakenly add a space after the url. This will remove any spaces from the beginning or end of the Url string before crawling.
